### PR TITLE
Python3, Ventana support, import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+This fork is based on the original repo in https://github.com/bgilbert/anonymize-slide
+
+Several users (markemus, r3m0chop and grenkoca) have updated the code to make it runnable with Python 3. Since non of their versions worked with my mrxs
+files I decided to fork the version from markemus in which I could fix the issues with the mrxs files. Please note that all these files are currently in the
+old mrxs format (with some of them being converted from the new into the old format). So far I did not test the new format.
+
+Please note that the original readme below does not respect the current state of the script.
+
+
+
 anonymize-slide
 ===============
 

--- a/anonymize-slide.py
+++ b/anonymize-slide.py
@@ -333,12 +333,10 @@ class MrxsFile(object):
         self._dat = RawConfigParser()
         self._dat.optionxform = str
         try:
-            # with open(self._slidedatfile, 'rb') as fh:
-            with open(self._slidedatfile, 'r') as fh:
+            with open(self._slidedatfile, 'r', encoding="utf-8-sig") as fh:
                 self._have_bom = (fh.read(len(UTF8_BOM)) == UTF8_BOM)
                 if not self._have_bom:
                     fh.seek(0)
-                # self._dat.readfp(fh)
                 self._dat.read_file(fh)
         except IOError:
             raise UnrecognizedFile


### PR DESCRIPTION
- Updated to python3 and tested on the supported formats. 
- Added support for the Ventana TIF format specified by openslide here: https://openslide.org/formats/ventana/
- Wrapped the anonymization in a function to allow it to be imported into other python modules.

I'm not 100% certain that it works for the MRXS format- it runs without error on a test image but I'm not sure how to check that the result is truly de-identified.